### PR TITLE
Fix socket connections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,12 @@ import React from 'react';
 import Chat from "@/components/Chat";
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
+import { MessageProps, ChannelMessage } from '@/utils/types/types'
+
+/**
+ *  The URL to the backend REST API
+ */
+const api: string = process.env.BACKEND_API!
 
 const ChatPage: React.FC = async () => {
   // Check if user is authenticated
@@ -14,9 +20,34 @@ const ChatPage: React.FC = async () => {
   if (!user) {
       return redirect('/login')
   }
+
+  // fetch previous messages
+  // for now hardcoding general
+  let previous: MessageProps[] = []
+  try {
+    const response = await fetch(api + '/channels/4/messages', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      // Map the differences between api and socket formats
+      previous = data.map((message: ChannelMessage) => ({
+        user: message.users.display_name,
+        body: message.body,
+        timestamp: message.created_at
+      }))
+    }
+  } catch (error) {
+    console.log('Failed to receive general chat messages: ', error)
+    redirect('/error')
+  }
+  
   return (
-    <Chat user={user} />
-    
+    <Chat user={user} previousMessages={previous} />
   );
 };
 

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -2,7 +2,7 @@
  * Initializes a socket.io client connection. Auth token is user.id
  * Socket connections must be rendered client-side and Nextjs renders server-side
  * by default, so this file must be marked with the 'use client' directive
- * Source: https://socket.io/how-to/use-with-nextjs#client 
+ * Source: https://socket.io/how-to/use-with-react 
  * TOOD: Add error handling
  */
 
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react'
 import { socket, updateSocketAuth } from '@/socket'
 //import { Socket } from 'socket.io-client'
 import { type User } from "@supabase/supabase-js"
-import {  MessageProps } from '@/components/Message'
+import { MessageProps } from '@/utils/types/types'
 import ChatInput, { ChatInputProps } from '@/components/ChatInput'
 import PreviousMessages from '@/components/PreviousMessages'
 import ChannelBar from '@/components/ChannelBar'
@@ -20,34 +20,37 @@ import UserList from '@/components/UserList'
 import styles from '@/app/ChatPage.module.css'
 
 
-export default function Chat({ user }: { user: User | null }) {
+export default function Chat({ user, previousMessages }: { user: User, previousMessages: MessageProps[] }) {
   const [msgBody, setMsgBody] = useState<string>('')
-  const [msgHistory, setMsgHistory] = useState<MessageProps[]>([])
+  const [msgHistory, setMsgHistory] = useState<MessageProps[]>(previousMessages)
   const [isConnected, setIsConnected] = useState(socket.connected)
 
+
   useEffect(() => {
-    if (user?.id) {
-      updateSocketAuth(user.id)
-    }
+    updateSocketAuth(user.id)
     socket.connect()
 
     return () => {
+      // When the user logs out or closes the page, disconnect the socket
       socket.disconnect()
     }
-  }, [user?.id])
+  }, [user.id])
 
   useEffect(() => {
     const onConnect = () => {
       setIsConnected(true)
     }
-
-    const onDisconnect = () => {
+    // If there is a connection error, try again with the auth token
+    const onError = (err: Error) => {
       setIsConnected(false)
-    }
-
-    const onError = () => {
-      if (user?.id) {
+      if (socket.active) {
+        // Temporary failure, not denied by the server
+        // update auth token and retry
         updateSocketAuth(user.id)
+      } else {
+        // connection was denied by the server, disconnect the socket
+        console.log(err.message)
+        socket.disconnect()
       }
     }
   
@@ -56,19 +59,16 @@ export default function Chat({ user }: { user: User | null }) {
     }
 
     socket.on('connect', onConnect)  
-    // TODO: load previous channel messages from Supabase and display
     socket.on('general', onIncomingMessage)
-    socket.on('disconnect', onDisconnect)
     socket.on('connect_error', onError)
 
     // Cleanup event listeners
     return () => {
       socket.off('connect', onConnect)
-      socket.off('disconnect', onDisconnect)
       socket.off('connect_error', onError)
       socket.off('general', onIncomingMessage)
     }
-  }, [msgHistory, user?.id])
+  }, [msgHistory, user.id])
 
   // Send a message to the general channel
   // TODO: Generalize this to send to the specified channel
@@ -76,7 +76,7 @@ export default function Chat({ user }: { user: User | null }) {
     event.preventDefault()
     if (isConnected) {
       const message: MessageProps = {
-        user: user?.id,
+        user: user.id,
         body: msgBody,
         timestamp: new Date().toISOString()
       }

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -3,13 +3,7 @@
  */
 import React from 'react';
 import styles from '@/app/ChatPage.module.css';
-
-// Represents format of messages between frontend and backend
-export interface MessageProps {
-  user: string | undefined;
-  body: string;
-  timestamp: string;
-}
+import { MessageProps } from '@/utils/types/types'
 
 const Message: React.FC<MessageProps> = ({ user, body, timestamp }) => {
   return (

--- a/components/PreviousMessages.tsx
+++ b/components/PreviousMessages.tsx
@@ -2,8 +2,10 @@
  * Represents the previous messages in a channel
  */
 import React from 'react';
-import Message, { MessageProps } from '@/components/Message';
+import Message from '@/components/Message';
+import { MessageProps } from '@/utils/types/types'
 import styles from '@/app/ChatPage.module.css';
+
 
 export default function PreviousMessages({ messages }: { messages: MessageProps[] }) {
     return (

--- a/socket.ts
+++ b/socket.ts
@@ -5,15 +5,16 @@ import { io } from "socket.io-client"
 const url = process.env.NEXT_PUBLIC_SOCKET_URL
 
 /**
- * Add comment here
- * Establish the socket manager
- * 
+ * Establish the socket manager and set autoConnect to false to avoid constant
+ * connection errors while the server waits for a user id
+ * TODO: set up event maps for the Socket type
  */
 export const socket = io(url, {
     transports: ["websocket"],
     autoConnect: false,
 })
 
+// Need user id for auth token, so set it up later
 export const updateSocketAuth = (token: string) => {
     socket.auth = { token }
 }

--- a/socket.ts
+++ b/socket.ts
@@ -1,0 +1,19 @@
+"use client"
+
+import { io } from "socket.io-client"
+
+const url = process.env.NEXT_PUBLIC_SOCKET_URL
+
+/**
+ * Add comment here
+ * Establish the socket manager
+ * 
+ */
+export const socket = io(url, {
+    transports: ["websocket"],
+    autoConnect: false,
+})
+
+export const updateSocketAuth = (token: string) => {
+    socket.auth = { token }
+}

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Types
+ */
+
+// interact with GET /channels/:channelId/messages
+export interface ChannelMessage {
+    body: string;
+    created_at: string
+    users: {
+        display_name: string;
+    };
+}
+
+// Communication format of socket messages sent between frontend and backend 
+export interface MessageProps {
+    user: string;
+    body: string;
+    timestamp: string;
+  }


### PR DESCRIPTION
1. Fixed the socket connections, client maintains one connection
    - recent changes to the ChannelBar component may interfere with this since the ChannelBar component is making a Supabase API call
    - since ChannelBar is nested into the Chat component, which requires a `user` object from Supabase anyway, ChannelBar could just take in a `user` object just like the Chat component does
2. need to add the env variable `BACKEND_API='https://scp-backend.hakkilab.engineer'` to fetch the previous messages, feel free to change this
3. Made a directory for types