### PR TITLE
Refactor/chat

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,14 @@
-// page.tsx
 import React from 'react';
 import Chat from "@/components/Chat";
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
-import { MessageProps, ChannelMessage, Channel } from '@/utils/types/types'
+import { Channel } from '@/utils/types/types'
+import { 
+  fetchAllChannelsForCurrentUser, 
+  fetchAllPreviousMessages,
+  fetchChannelUsers 
+} from '@/utils/api/api';
 
-
-/**
- *  The URL to the backend REST API
- */
-const api: string = process.env.NEXT_PUBLIC_BACKEND_API!
-const apiHeaders = {
-  method: 'GET',
-  headers: {
-    'Content-Type': 'application/json'
-  },
-}
 
 /**
  * The entry point to our application.
@@ -34,40 +27,20 @@ export default async function Page() {
   }
 
   // fetch all channels the user is subscribed to
-  let channels: Channel[] = []
-  try {
-    const chanResponse = await fetch(api + `/users/${user.id}/channels`, apiHeaders)
-    if (chanResponse.ok) {
-      const chanData = await chanResponse.json()
-      channels = chanData
-    }
-  } catch (error) {
-    console.log('Failed to get channels for user: ', error)
-  }
+  const channels: Channel[] = await fetchAllChannelsForCurrentUser(user)
 
   // fetch previous messages
-  // k: channel_id v: an array of all messages received
-  const previousMessages = new Map<number, MessageProps[]>
-  for (const channel of channels) {
-    try {
-      const response = await fetch(`${api}/channels/${channel.id}/messages`, apiHeaders)
-      if (response.ok) {
-        const data = await response.json()
-        // Map the differences between api and socket formats
-        const messages: MessageProps[] = data.map((message: ChannelMessage) => ({
-          user: message.users.display_name,
-          body: message.body,
-          channel_id: channel.id,
-          timestamp: message.created_at
-        }))
-        previousMessages.set(channel.id, messages)
-      }
-    } catch (error) {
-      console.log(`Failed to retrieve messages for channel ${channel.id}`, error)
-    }
-  }
+  const previousMessages = await fetchAllPreviousMessages(channels)
+
+  // fetch all users in a channel
+  const channelUsers = await fetchChannelUsers(channels)
 
   return (
-    <Chat user={user} previousMessages={previousMessages} channels={channels}/>
+    <Chat 
+      user={user}
+      previousMessages={previousMessages}
+      channels={channels}
+      channelUsers={channelUsers}
+      />
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ export default async function Page() {
   // fetch previous messages
   const previousMessages = await fetchAllPreviousMessages(channels)
 
-  // fetch all users in a channel
+  // fetch all users for all channels a user is subscribed to
   const channelUsers = await fetchChannelUsers(channels)
 
   return (

--- a/utils/api/api.ts
+++ b/utils/api/api.ts
@@ -1,0 +1,80 @@
+import { Channel, MessageProps, ChannelMessage, ChannelUser } from '@/utils/types/types'
+import { type User } from '@supabase/supabase-js'
+
+/**
+ *  The URL to the backend REST API
+ */
+const api: string = process.env.NEXT_PUBLIC_BACKEND_API!
+const apiHeaders = {
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+}
+/**
+ * Fetch all channels the given user is subscribed to
+ * @param user the current user - a Supabase type
+ * @returns an array of all channels the user subscribed to, or an empty array
+ */
+export async function fetchAllChannelsForCurrentUser(user: User) {
+    try {
+        const response = await fetch(`${api}/users/${user.id}/channels`, apiHeaders)
+        if (response.ok) {
+            const data: Channel[] = await response.json()
+            return data
+        }
+    } catch(error) {
+        console.log(`Failed to get channels for user ${user.id}: ${error}`)
+    }
+    return []
+}
+
+  // fetch previous messages
+  // k: channel_id v: an array of all messages received
+
+/**
+ * Fetch all previous messages for the channels the current user is subscribed to
+ * Use this in the root page.tsx after fetchAllChannelsForCurrentUser
+ * @param channels the channels the current user is subscribed to
+ * @returns a map of all previous messages - k: channel_id, v: an array of all messages received
+ */
+export async function fetchAllPreviousMessages(channels: Channel[]) {
+    const previousMessages = new Map<number, MessageProps[]>
+    for (const channel of channels) {
+        try {
+            const response = await fetch(`${api}/channels/${channel.id}/messages`, apiHeaders)
+            if (response.ok) {
+                const data = await response.json()
+                // Map the differences between api and socket formats
+                const messages: MessageProps[] = data.map((message: ChannelMessage) => ({
+                    user: message.users.display_name,
+                    body: message.body,
+                    channel_id: channel.id,
+                    timestamp: message.created_at
+                }))
+                previousMessages.set(channel.id, messages)
+            }
+        } catch (error) {
+            console.log(`Failed to retrieve messages for channel ${channel.id}: ${error}`)
+        }
+    }
+    return previousMessages
+}
+
+
+export async function fetchChannelUsers(channels: Channel[]) {
+    const channelsAndUsers = new Map<number, ChannelUser[]>
+    for (const channel of channels) {
+        try {
+            const response = await fetch(`${api}/channels/${channel.id}/users`, apiHeaders);
+            if (response.ok) {
+              const users = await response.json();
+              const usersWithStatus: ChannelUser[] = users.map((user: ChannelUser) => ({...user, status: 'online'}));
+              channelsAndUsers.set(channel.id, usersWithStatus)
+            }
+          } catch (error) {
+            console.error('Error with users', error);
+          }
+    }
+    return channelsAndUsers
+};


### PR DESCRIPTION
1. Moved all backend API related code to `utils/api` directory
2. Refactored `fetchChannelUsers` to take in an array of Channels in case the user is subbed to multiple channels. Returns a map where the key is the `channel_id` and the value is an array of `ChannelUsers`
3. Made it so `fetchChannelUsers` is only called on the initial page load up rather than when `currentChannel`'s state changes. We can update it similarly to how we update `msgHistory` once we add the ability to join new channels.
4. refactored page.tsx
5. Fixed a bug with the Chat component where msgHistory was incorrectly being set

These changes should fix the error (https://react.dev/errors/418?args[]=) we get on the current version of the app.